### PR TITLE
Add CORS library and set default CORS settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ lazy val root = (project in file("."))
       "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion,
       "com.typesafe.akka" %% "akka-http-xml"        % akkaHttpVersion,
       "com.typesafe.akka" %% "akka-stream"          % akkaVersion,
+      "ch.megard"         %% "akka-http-cors"       % "0.4.1",
 
       "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpVersion % Test,
       "com.typesafe.akka" %% "akka-testkit"         % akkaVersion     % Test,


### PR DESCRIPTION
Require CORS handling to allow browser to communicate with server. Using default CORS settings initially to enable local development. See here for futher details on akka cors library: https://github.com/lomigmegard/akka-http-cors