### PR TITLE
 Move DB connection parameter paths into environment variables

### DIFF
--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/DbConfig.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/DbConfig.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.core.db
 
 import software.amazon.awssdk.services.ssm.SsmClient
-import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest
+import software.amazon.awssdk.services.ssm.model.GetParametersRequest
 
 import scala.collection.JavaConverters._
 
@@ -24,14 +24,20 @@ object DevDbConfig extends DbConfig {
 // caching.
 object PrototypeDbConfig extends DbConfig {
 
+  private val dbUrlParamPath = sys.env("DB_URL_PARAM_PATH")
+  private val dbUsernameParamPath = sys.env("DB_USERNAME_PARAM_PATH")
+  private val dbPasswordParamPath = sys.env("DB_PASSWORD_PARAM_PATH")
+
   private val ssmClient = SsmClient.create
 
-  private val request = GetParametersByPathRequest.builder.path("/tdr/prototype/api/db").build
-  private val response = ssmClient.getParametersByPath(request)
+  private val request = GetParametersRequest.builder
+    .names(dbUrlParamPath, dbUsernameParamPath, dbPasswordParamPath)
+    .build
+  private val response = ssmClient.getParameters(request)
 
   private val parameters = response.parameters.asScala.map(param => (param.name, param.value)).toMap
 
-  override def url: String = parameters("/tdr/prototype/api/db/url")
-  override def username: String = parameters("/tdr/prototype/api/db/username")
-  override def password: String = parameters("/tdr/prototype/api/db/password")
+  override def url: String = parameters(dbUrlParamPath)
+  override def username: String = parameters(dbUsernameParamPath)
+  override def password: String = parameters(dbPasswordParamPath)
 }

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/httpserver/ApiServer.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/httpserver/ApiServer.scala
@@ -17,7 +17,7 @@ object ApiServer extends App with Routes {
 
   val graphQlActor: ActorRef = system.actorOf(GraphQlActor.props, "graphQlActor")
 
-  lazy val routes: Route = userRoutes
+  lazy val routes: Route = graphQlRoutes
 
   val serverBinding: Future[Http.ServerBinding] = Http().bindAndHandle(routes, "localhost", 8080)
 

--- a/src/main/scala/uk/gov/nationalarchives/tdr/api/httpserver/Routes.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tdr/api/httpserver/Routes.scala
@@ -32,7 +32,7 @@ trait Routes extends JsonSupport {
 
   //Use CORS' default settings to get local development to work.
   //Settings can be overridden using conf file or in code: https://github.com/lomigmegard/akka-http-cors
-  lazy val userRoutes: Route = cors() {
+  lazy val graphQlRoutes: Route = cors() {
       pathPrefix("graphql") {
         post {
           entity(as[GraphQlRequest]) {


### PR DESCRIPTION
This lets us use different parameters in different environments. We can use Terraform to set the paths as environment variables in AWS Lambda.

@TomJKing @MancunianSam You've spent more time thinking about the parameter store and Terraform - does this approach look OK to you?