### PR TITLE
Tk add bulk file create

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,11 @@ mutation {
 
 ```
 ### "```CreateFile```"
+
+#### Postman Query
 ```
-mutation { 
-    createFile(path: "my/path/file2.txt", id: 5) {
+mutation($input: CreateFileInput!) { 
+    createFile(createFileInput: $input) {
         path,
         id,
         consignment {
@@ -235,5 +237,55 @@ mutation {
             name
         }
     }
+}
+```
+
+#### Postman GraphQl Variables
+```
+{
+    "input": {
+	    "id": 321, 
+	    "path": "file/path/file1.txt", 
+	    "consignmentId": 1
+    }
+}
+```
+
+### "```CreateMultipleFiles```"
+
+#### Postman Query
+```
+mutation($input: [CreateFileInput!]!) { 
+    createMultipleFiles(createFileInputs: $input) {
+        path,
+        id,
+        consignment {
+            id,
+            name
+        }
+    }
+}
+```
+
+#### Postman GraphQl Variables
+```
+{
+    "input": [
+        {
+            "id": 321, 
+            "path": "file/path/file1.txt", 
+            "consignmentId": 1
+    	},
+    	{
+            "id": 321, 
+            "path": "file/path/file2.txt", 
+            "consignmentId": 1
+    	},
+    	{
+            "id": 321, 
+            "path": "file/path/file3.txt", 
+            "consignmentId": 2
+    	}
+    ]
 }
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ lazy val core = (project in file("core"))
       "org.slf4j" % "slf4j-nop" % "1.7.26",
       "com.typesafe.slick" %% "slick-hikaricp" % "3.3.1",
       "org.postgresql" % "postgresql" % "42.2.6",
-      "software.amazon.awssdk" % "ssm" % "2.7.23"
+      "software.amazon.awssdk" % "ssm" % "2.7.23",
+      "io.circe" %% "circe-generic" % "0.9.3",      
     )
   )
 
@@ -27,8 +28,7 @@ lazy val lambda = (project in file("lambda"))
     libraryDependencies ++= Seq(
       // TODO: Is there an equivalent in the SDK v2?
       "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
-      "io.circe" %% "circe-parser" % "0.9.3",
-      "io.circe" %% "circe-generic" % "0.9.3",
+      "io.circe" %% "circe-parser" % "0.9.3",      
     ),
     assemblyMergeStrategy in assembly := {
       case "META-INF/io.netty.versions.properties" => MergeStrategy.first
@@ -49,8 +49,7 @@ lazy val root = (project in file("."))
       "com.typesafe.akka" %% "akka-stream"          % akkaVersion,
       "ch.megard"         %% "akka-http-cors"       % "0.4.1",
       "de.heikoseeberger" %% "akka-http-circe"      % "1.27.0",
-      "io.circe"          %% "circe-generic"        % "0.9.3",
-
+     
       "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpVersion % Test,
       "com.typesafe.akka" %% "akka-testkit"         % akkaVersion     % Test,
       "com.typesafe.akka" %% "akka-stream-testkit"  % akkaVersion     % Test,

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/GraphQlServer.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/GraphQlServer.scala
@@ -6,7 +6,7 @@ import sangria.execution.Executor
 import sangria.macros.derive._
 import sangria.marshalling.circe._
 import sangria.parser.QueryParser
-import sangria.schema.{Argument, Field, IntType, ListType, ObjectType, OptionType, Schema, StringType, fields}
+import sangria.schema.{Argument, Field, IntType, ListInputType, ListType, ObjectType, OptionType, Schema, StringType, fields}
 import uk.gov.nationalarchives.tdr.api.core.db.dao.{ConsignmentDao, FileDao, SeriesDao}
 import uk.gov.nationalarchives.tdr.api.core.graphql.RequestContext
 import uk.gov.nationalarchives.tdr.api.core.graphql.service.{ConsignmentService, FileService, SeriesService}
@@ -14,21 +14,27 @@ import uk.gov.nationalarchives.tdr.api.core.graphql.service.{ConsignmentService,
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
+import io.circe.generic.auto._
 
 object GraphQlServer {
 
   implicit private val SeriesType: ObjectType[Unit, Series] = deriveObjectType[Unit, Series]()
   implicit private val ConsignmentType: ObjectType[Unit, Consignment] = deriveObjectType[Unit, Consignment]()
   implicit private val FileType: ObjectType[Unit, File] = deriveObjectType[Unit, File]()
+  implicit private val CreateFileInputType = deriveInputObjectType[CreateFileInput]()
 
   private val ConsignmentNameArg = Argument("name", StringType)
   private val ConsignmentIdArg = Argument("id", IntType)
   private val SeriesIdArg = Argument("seriesId", IntType)
-  private val filePathArg = Argument("path", StringType)
   private val FileIdArg = Argument("id", IntType)
+  private val FileInputArg = Argument("createFileInput", CreateFileInputType)
+  private val MultipleFileInputsArg = Argument("createFileInputs", ListInputType(CreateFileInputType))
 
   private val QueryType = ObjectType("Query", fields[RequestContext, Unit](
-    Field("getConsignments", ListType(ConsignmentType), resolve = ctx => ctx.ctx.consignments.all),
+    Field(
+      "getConsignments",
+      ListType(ConsignmentType),
+      resolve = ctx => ctx.ctx.consignments.all),
     Field(
       "getConsignment",
       OptionType(ConsignmentType),
@@ -56,8 +62,14 @@ object GraphQlServer {
     Field(
       "createFile",
       FileType,
-      arguments = List(filePathArg, ConsignmentIdArg),
-      resolve = ctx => ctx.ctx.files.create(ctx.arg(filePathArg), ctx.arg(ConsignmentIdArg))
+      arguments = List(FileInputArg),
+      resolve = ctx => ctx.ctx.files.create(ctx.arg(FileInputArg))
+    ),
+    Field(
+      "createMultipleFiles",
+      ListType(FileType),
+      arguments = List(MultipleFileInputsArg),
+      resolve = ctx => ctx.ctx.files.createMultiple(ctx.arg(MultipleFileInputsArg))
     )
   ))
 
@@ -88,3 +100,4 @@ case class GraphQlRequest(query: String, operationName: Option[String], variable
 case class Series(id: Int, name: String, description: String)
 case class Consignment(id: Int, name: String, series: Series)
 case class File(id: Int, path: String, consignment: Consignment)
+case class CreateFileInput(id: Int, path: String, consignmentId: Int)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/GraphQlServer.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/GraphQlServer.scala
@@ -100,4 +100,4 @@ case class GraphQlRequest(query: String, operationName: Option[String], variable
 case class Series(id: Int, name: String, description: String)
 case class Consignment(id: Int, name: String, series: Series)
 case class File(id: Int, path: String, consignment: Consignment)
-case class CreateFileInput(id: Int, path: String, consignmentId: Int)
+case class CreateFileInput(path: String, consignmentId: Int)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.core.graphql.service
 
 import uk.gov.nationalarchives.tdr.api.core
-import uk.gov.nationalarchives.tdr.api.core.File
+import uk.gov.nationalarchives.tdr.api.core.{CreateFileInput, File}
 import uk.gov.nationalarchives.tdr.api.core.db.dao.{ConsignmentDao, FileDao}
 import uk.gov.nationalarchives.tdr.api.core.db.model.{ConsignmentRow, FileRow}
 
@@ -31,8 +31,17 @@ class FileService(fileDao: FileDao, consignmentService: ConsignmentService)(impl
     })
   }
 
-  def create(path: String, consignmentId: Int): Future[File] = {
-    val newFile = FileRow(None, path, consignmentId)
+  def createMultiple(inputs: Seq[CreateFileInput]): Future[Seq[File]] = {
+    val files = inputs.map(
+      input => {
+        create(input)
+      }
+    )
+    Future.sequence(files)
+  }
+
+  def create(input: CreateFileInput): Future[File] = {
+    val newFile = FileRow(None, input.path, input.consignmentId)
     val result = fileDao.create(newFile)
 
     result.flatMap(persistedFile =>

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
@@ -32,6 +32,7 @@ class FileService(fileDao: FileDao, consignmentService: ConsignmentService)(impl
   }
 
   def createMultiple(inputs: Seq[CreateFileInput]): Future[Seq[File]] = {
+    //TODO: this should be a sql that adds mutliple rows instead of iterating
     val files = inputs.map(
       input => {
         create(input)


### PR DESCRIPTION
Adding support for creating multiple file rows in a single mutation. A new SQL should be added instead of the current iteration in the FileService.scala. Documentation updated to reflect the new mutation format for Postman