### PR TITLE
Enable GraphQL schema generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ environment variables as in the CLI option above.
 Both options will start a server at http://localhost:8080/. It currently just provides a GraphQL POST endpoint at
 http://127.0.0.1:8080/graphql, which you can send queries to with curl, Postman or a GraphQL client.
 
+### Generate GraphQL schema
+
+To generate a schema from the Sangria code to use in Postman or a client application, run:
+
+```
+sbt graphqlSchemaGen
+```
+
+This will output a schema file to `target/sbt-graphql/schema.graphql`.
+
+To use the schema in Postman, see the [Postman guide to importing GraphQL schemas][postman-import-graphql].
+
+[postman-import-graphql]: https://learning.getpostman.com/docs/postman/sending_api_requests/graphql/#importing-graphql-schemas
+
 ## Deployment
 
 ### Infrastructure

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,10 @@ ThisBuild / version := "0.1.0-SNAPSHOT"
 lazy val akkaHttpVersion = "10.1.9"
 lazy val akkaVersion    = "2.6.0-M5"
 
+enablePlugins(GraphQLSchemaPlugin)
+
+graphqlSchemaSnippet := "uk.gov.nationalarchives.tdr.api.core.graphql.GraphQlTypes.schema"
+
 lazy val core = (project in file("core"))
   .settings(
     name := "TDR GraphQL API core",
@@ -17,7 +21,7 @@ lazy val core = (project in file("core"))
       "com.typesafe.slick" %% "slick-hikaricp" % "3.3.1",
       "org.postgresql" % "postgresql" % "42.2.6",
       "software.amazon.awssdk" % "ssm" % "2.7.23",
-      "io.circe" %% "circe-generic" % "0.9.3",      
+      "io.circe" %% "circe-generic" % "0.9.3",
     )
   )
 
@@ -56,3 +60,5 @@ lazy val root = (project in file("."))
       "org.scalatest"     %% "scalatest"            % "3.0.5"         % Test,
     )
   ).dependsOn(core)
+
+mainClass in (Compile, run) := Some("uk.gov.nationalarchives.tdr.api.httpserver.ApiServer")

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/GraphQlServer.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/GraphQlServer.scala
@@ -1,18 +1,13 @@
 package uk.gov.nationalarchives.tdr.api.core
 
-import java.util.Date
-
 import io.circe.Json
-import io.circe.generic.auto._
 import sangria.ast.Document
 import sangria.execution.Executor
-import sangria.macros.derive._
 import sangria.marshalling.circe._
 import sangria.parser.QueryParser
-import sangria.schema.{Argument, BooleanType, Field, IntType, ListInputType, ListType, ObjectType, OptionType, Schema, StringType, fields}
 import uk.gov.nationalarchives.tdr.api.core.db.dao._
-import uk.gov.nationalarchives.tdr.api.core.graphql.RequestContext
 import uk.gov.nationalarchives.tdr.api.core.graphql.service._
+import uk.gov.nationalarchives.tdr.api.core.graphql.{GraphQlTypes, RequestContext}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -20,96 +15,12 @@ import scala.util.{Failure, Success, Try}
 
 object GraphQlServer {
 
-  implicit private val SeriesType: ObjectType[Unit, Series] = deriveObjectType[Unit, Series]()
-  implicit private val ConsignmentType: ObjectType[Unit, Consignment] = deriveObjectType[Unit, Consignment]()
-  implicit private val FileType: ObjectType[Unit, File] = deriveObjectType[Unit, File]()
-  implicit private val CreateFileInputType = deriveInputObjectType[CreateFileInput]()
-
-  private val ConsignmentNameArg = Argument("name", StringType)
-  private val ConsignmentIdArg = Argument("id", IntType)
-  private val SeriesIdArg = Argument("seriesId", IntType)
-  private val FileIdArg = Argument("id", IntType)
-  private val ChecksumArg = Argument("checksum", StringType)
-  private val VirusCheckStatusArg = Argument("status", StringType)
-  private val PronomIdArg = Argument("pronomId", StringType)
-  private val FileInputArg = Argument("createFileInput", CreateFileInputType)
-  private val MultipleFileInputsArg = Argument("createFileInputs", ListInputType(CreateFileInputType))
-
-  private val QueryType = ObjectType("Query", fields[RequestContext, Unit](
-    Field(
-      "getConsignments",
-      ListType(ConsignmentType),
-      resolve = ctx => ctx.ctx.consignments.all),
-    Field(
-      "getConsignment",
-      OptionType(ConsignmentType),
-      arguments = List(ConsignmentIdArg),
-      resolve = ctx => ctx.ctx.consignments.get(ctx.arg(ConsignmentIdArg))
-    ),
-    Field(
-      "getFile",
-      OptionType(FileType),
-      arguments = List(FileIdArg),
-      resolve = ctx => ctx.ctx.files.get(ctx.arg(FileIdArg))
-    ),
-    Field(
-      "getFiles",
-      ListType(FileType),
-      resolve = ctx => ctx.ctx.files.all)
-  ))
-
-  private val MutationType = ObjectType("Mutation", fields[RequestContext, Unit](
-    Field(
-      "createConsignment",
-      ConsignmentType,
-      arguments = List(ConsignmentNameArg, SeriesIdArg),
-      resolve = ctx => ctx.ctx.consignments.create(ctx.arg(ConsignmentNameArg), ctx.arg(SeriesIdArg))),
-    Field(
-      "createFile",
-      FileType,
-      arguments = List(FileInputArg),
-      resolve = ctx => ctx.ctx.files.create(ctx.arg(FileInputArg))
-    ),
-    Field(
-      "updateServerSideFileChecksum",
-      BooleanType,
-      arguments = List(FileIdArg, ChecksumArg),
-      resolve = ctx => ctx.ctx.fileStatuses.updateServerSideChecksum(ctx.arg(FileIdArg), ctx.arg(ChecksumArg))
-    ),
-    Field(
-      "updateClientSideFileChecksum",
-      BooleanType,
-      arguments = List(FileIdArg, ChecksumArg),
-      resolve = ctx => ctx.ctx.fileStatuses.updateClientSideChecksum(ctx.arg(FileIdArg), ctx.arg(ChecksumArg))
-    ),
-      Field(
-      "updateVirusCheck",
-      BooleanType,
-      arguments = List(FileIdArg, VirusCheckStatusArg),
-      resolve = ctx => ctx.ctx.fileStatuses.updateVirusCheck(ctx.arg(FileIdArg), ctx.arg(VirusCheckStatusArg))
-    ),
-    Field("updateFileFormat",
-      BooleanType,
-      arguments = List(FileIdArg, PronomIdArg),
-      resolve = ctx => ctx.ctx.fileFormats.create(ctx.arg(PronomIdArg), ctx.arg(FileIdArg))
-    ),
-    Field(
-      "createMultipleFiles",
-      ListType(FileType),
-      arguments = List(MultipleFileInputsArg),
-      resolve = ctx => ctx.ctx.files.createMultiple(ctx.arg(MultipleFileInputsArg))
-    )
-  ))
-
-  private val schema = Schema(QueryType, Some(MutationType))
-
   private val seriesService = new SeriesService(new SeriesDao)
   private val consignmentService = new ConsignmentService(new ConsignmentDao, seriesService)
   private val fileStatusService = new FileStatusService(new FileStatusDao())
   private val fileService = new FileService(new FileDao, fileStatusService, consignmentService)
   private val fileFormatService = new FileFormatService(new FileFormatDao())
   private val requestContext = new RequestContext(seriesService, consignmentService, fileService, fileStatusService, fileFormatService)
-
 
   def send(request: GraphQlRequest): Future[Json] = {
     println(s"Got GraphQL request '$request'")
@@ -119,7 +30,7 @@ object GraphQlServer {
     query match {
       case Success(doc) =>
         val variables = request.variables.getOrElse(Json.obj())
-        Executor.execute(schema, doc, requestContext, operationName = request.operationName, variables = variables)
+        Executor.execute(GraphQlTypes.schema, doc, requestContext, operationName = request.operationName, variables = variables)
       case Failure(e) =>
         Future.failed(e)
     }
@@ -128,9 +39,4 @@ object GraphQlServer {
 
 case class GraphQlRequest(query: String, operationName: Option[String], variables: Option[Json])
 
-case class Series(id: Int, name: String, description: String)
-case class Consignment(id: Int, name: String, series: Series)
-case class FileStatus(id: Int, clientSideChecksum: String, serverSideChecksum: String, fileFormatVerified: Boolean, fileId: Int, antivirusStatus: String)
-//TODO: need to define a custom scalar date type to store dates in DB
-case class File(id: Int, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: String, fileName: String)
-case class CreateFileInput(path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: String, fileName: String, clientSideChecksum: String)
+

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
@@ -1,0 +1,99 @@
+package uk.gov.nationalarchives.tdr.api.core.graphql
+
+import sangria.marshalling.circe._
+import io.circe.generic.auto._
+import sangria.macros.derive._
+import sangria.schema.{Argument, BooleanType, Field, InputObjectType, IntType, ListInputType, ListType, ObjectType, OptionType, Schema, StringType, fields}
+
+object GraphQlTypes {
+
+  implicit private val SeriesType: ObjectType[Unit, Series] = deriveObjectType[Unit, Series]()
+  implicit private val ConsignmentType: ObjectType[Unit, Consignment] = deriveObjectType[Unit, Consignment]()
+  implicit private val FileType: ObjectType[Unit, File] = deriveObjectType[Unit, File]()
+  implicit private val CreateFileInputType: InputObjectType[CreateFileInput] = deriveInputObjectType[CreateFileInput]()
+
+  private val ConsignmentNameArg = Argument("name", StringType)
+  private val ConsignmentIdArg = Argument("id", IntType)
+  private val SeriesIdArg = Argument("seriesId", IntType)
+  private val FileIdArg = Argument("id", IntType)
+  private val ChecksumArg = Argument("checksum", StringType)
+  private val VirusCheckStatusArg = Argument("status", StringType)
+  private val PronomIdArg = Argument("pronomId", StringType)
+  private val FileInputArg = Argument("createFileInput", CreateFileInputType)
+  private val MultipleFileInputsArg = Argument("createFileInputs", ListInputType(CreateFileInputType))
+
+  private val QueryType = ObjectType("Query", fields[RequestContext, Unit](
+    Field(
+      "getConsignments",
+      ListType(ConsignmentType),
+      resolve = ctx => ctx.ctx.consignments.all),
+    Field(
+      "getConsignment",
+      OptionType(ConsignmentType),
+      arguments = List(ConsignmentIdArg),
+      resolve = ctx => ctx.ctx.consignments.get(ctx.arg(ConsignmentIdArg))
+    ),
+    Field(
+      "getFile",
+      OptionType(FileType),
+      arguments = List(FileIdArg),
+      resolve = ctx => ctx.ctx.files.get(ctx.arg(FileIdArg))
+    ),
+    Field(
+      "getFiles",
+      ListType(FileType),
+      resolve = ctx => ctx.ctx.files.all)
+  ))
+
+  private val MutationType = ObjectType("Mutation", fields[RequestContext, Unit](
+    Field(
+      "createConsignment",
+      ConsignmentType,
+      arguments = List(ConsignmentNameArg, SeriesIdArg),
+      resolve = ctx => ctx.ctx.consignments.create(ctx.arg(ConsignmentNameArg), ctx.arg(SeriesIdArg))),
+    Field(
+      "createFile",
+      FileType,
+      arguments = List(FileInputArg),
+      resolve = ctx => ctx.ctx.files.create(ctx.arg(FileInputArg))
+    ),
+    Field(
+      "updateServerSideFileChecksum",
+      BooleanType,
+      arguments = List(FileIdArg, ChecksumArg),
+      resolve = ctx => ctx.ctx.fileStatuses.updateServerSideChecksum(ctx.arg(FileIdArg), ctx.arg(ChecksumArg))
+    ),
+    Field(
+      "updateClientSideFileChecksum",
+      BooleanType,
+      arguments = List(FileIdArg, ChecksumArg),
+      resolve = ctx => ctx.ctx.fileStatuses.updateClientSideChecksum(ctx.arg(FileIdArg), ctx.arg(ChecksumArg))
+    ),
+    Field(
+      "updateVirusCheck",
+      BooleanType,
+      arguments = List(FileIdArg, VirusCheckStatusArg),
+      resolve = ctx => ctx.ctx.fileStatuses.updateVirusCheck(ctx.arg(FileIdArg), ctx.arg(VirusCheckStatusArg))
+    ),
+    Field("updateFileFormat",
+      BooleanType,
+      arguments = List(FileIdArg, PronomIdArg),
+      resolve = ctx => ctx.ctx.fileFormats.create(ctx.arg(PronomIdArg), ctx.arg(FileIdArg))
+    ),
+    Field(
+      "createMultipleFiles",
+      ListType(FileType),
+      arguments = List(MultipleFileInputsArg),
+      resolve = ctx => ctx.ctx.files.createMultiple(ctx.arg(MultipleFileInputsArg))
+    )
+  ))
+
+  val schema: Schema[RequestContext, Unit] = Schema(QueryType, Some(MutationType))
+}
+
+case class Series(id: Int, name: String, description: String)
+case class Consignment(id: Int, name: String, series: Series)
+case class FileStatus(id: Int, clientSideChecksum: String, serverSideChecksum: String, fileFormatVerified: Boolean, fileId: Int, antivirusStatus: String)
+//TODO: need to define a custom scalar date type to store dates in DB
+case class File(id: Int, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: String, fileName: String)
+case class CreateFileInput(path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: String, fileName: String, clientSideChecksum: String)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/ConsignmentService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/ConsignmentService.scala
@@ -2,8 +2,7 @@ package uk.gov.nationalarchives.tdr.api.core.graphql.service
 
 import uk.gov.nationalarchives.tdr.api.core.db.dao.ConsignmentDao
 import uk.gov.nationalarchives.tdr.api.core.db.model.ConsignmentRow
-import uk.gov.nationalarchives.tdr.api.core
-import uk.gov.nationalarchives.tdr.api.core.Consignment
+import uk.gov.nationalarchives.tdr.api.core.graphql.Consignment
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -13,7 +12,7 @@ class ConsignmentService(consignmentDao: ConsignmentDao, seriesService: SeriesSe
     consignmentDao.all.flatMap(consignmentRows => {
       val consignments = consignmentRows.map(consignmentRow =>
         seriesService.get(consignmentRow.seriesId).map(series =>
-          core.Consignment(consignmentRow.id.get, consignmentRow.name, series.get)
+          Consignment(consignmentRow.id.get, consignmentRow.name, series.get)
         )
       )
       Future.sequence(consignments)
@@ -23,7 +22,7 @@ class ConsignmentService(consignmentDao: ConsignmentDao, seriesService: SeriesSe
   def get(id: Int): Future[Option[Consignment]] = {
     consignmentDao.get(id).flatMap(_.map(consignmentRow =>
       seriesService.get(consignmentRow.seriesId).map(series =>
-        core.Consignment(consignmentRow.id.get, consignmentRow.name, series.get)
+        Consignment(consignmentRow.id.get, consignmentRow.name, series.get)
       )
     ) match {
       case Some(f) => f.map(Some(_))
@@ -37,7 +36,7 @@ class ConsignmentService(consignmentDao: ConsignmentDao, seriesService: SeriesSe
 
     result.flatMap(persistedConsignment =>
       seriesService.get(persistedConsignment.seriesId).map(series =>
-        core.Consignment(persistedConsignment.id.get, persistedConsignment.name, series.get)
+        Consignment(persistedConsignment.id.get, persistedConsignment.name, series.get)
       )
     )
   }

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileStatusService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileStatusService.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.core.graphql.service
 
-import uk.gov.nationalarchives.tdr.api.core.FileStatus
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileStatusDao
+import uk.gov.nationalarchives.tdr.api.core.graphql.FileStatus
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/SeriesService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/SeriesService.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.core.graphql.service
 
 import uk.gov.nationalarchives.tdr.api.core.db.dao.SeriesDao
-import uk.gov.nationalarchives.tdr.api.core.Series
+import uk.gov.nationalarchives.tdr.api.core.graphql.Series
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+
+addSbtPlugin("rocks.muki" % "sbt-graphql" % "0.13.0")


### PR DESCRIPTION
The first commit is a refactoring to make schema generation easier. It splits the GraphQL code into two objects: `GraphQlServer`, which handles query execution, and `GraphQlTypes`, which defines the types and the schema. Splitting the code means that `GraphQlTypes` is entirely static. If I hadn't done this step, you would have needed to provide DB connection details just to generate the schema file, because sbt would had to have to loaded the whole of `GraphQlServer`.

The second commit adds [sbt-graphql](https://github.com/muuki88/sbt-graphql) so that we can generate schema files.

Here's an example of what it generates at the moment:

```
type Consignment {
  id: Int!
  name: String!
  series: Series!
}

input CreateFileInput {
  path: String!
  consignmentId: Int!
  fileSize: Int!
  lastModifiedDate: String!
  fileName: String!
  clientSideChecksum: String!
}

type File {
  id: Int!
  path: String!
  consignmentId: Int!
  fileSize: Int!
  lastModifiedDate: String!
  fileName: String!
}

type Mutation {
  createConsignment(name: String!, seriesId: Int!): Consignment!
  createFile(createFileInput: CreateFileInput!): File!
  updateServerSideFileChecksum(id: Int!, checksum: String!): Boolean!
  updateClientSideFileChecksum(id: Int!, checksum: String!): Boolean!
  updateVirusCheck(id: Int!, status: String!): Boolean!
  updateFileFormat(id: Int!, pronomId: String!): Boolean!
  createMultipleFiles(createFileInputs: [CreateFileInput!]!): [File!]!
}

type Query {
  getConsignments: [Consignment!]!
  getConsignment(id: Int!): Consignment
  getFile(id: Int!): File
  getFiles: [File!]!
}

type Series {
  id: Int!
  name: String!
  description: String!
}
```

I've tried importing it into Postman, and it autocompletes GraphQL queries nicely. :+1: 