### PR TITLE
Make all columns in file table mandatory

### DIFF
--- a/migrations/sql/V8__Make_file_columns_mandatory.sql
+++ b/migrations/sql/V8__Make_file_columns_mandatory.sql
@@ -1,0 +1,11 @@
+ALTER TABLE file
+  ALTER COLUMN file_size
+  SET NOT NULL;
+
+ALTER TABLE file
+  ALTER COLUMN last_modified_date
+  SET NOT NULL;
+
+ALTER TABLE file
+  ALTER COLUMN file_name
+  SET NOT NULL;


### PR DESCRIPTION
Add a `not null` constraint to all columns in the `file` table which didn't have it already.

This makes the table definition consistent with the `FileTable` class in Slick, which doesn't allow these values to be `None`.

All the columns should be mandatory because we know all of the file details at the point where we create a file. We determine the file path, size, last modified, etc. when the user uploads the file.