### PR TITLE
Switch File IDs from ints to UUIDs

### DIFF
--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
@@ -1,13 +1,13 @@
 package uk.gov.nationalarchives.tdr.api.core.db.dao
 
-import java.util.Date
+import java.util.UUID
 
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{TableQuery, Tag}
 import uk.gov.nationalarchives.tdr.api.core.db.DbConnection
+import uk.gov.nationalarchives.tdr.api.core.db.dao.ConsignmentDao.consignments
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileDao.files
 import uk.gov.nationalarchives.tdr.api.core.db.model.FileRow
-import uk.gov.nationalarchives.tdr.api.core.db.dao.ConsignmentDao.consignments
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -20,7 +20,7 @@ class FileDao(implicit val executionContext: ExecutionContext) {
     db.run(files.result)
   }
 
-  def get(id: Int): Future[Option[FileRow]] = {
+  def get(id: UUID): Future[Option[FileRow]] = {
     db.run(files.filter(_.id === id).result).map(_.headOption)
   }
 
@@ -35,7 +35,7 @@ object FileDao {
 }
 
 class FileTable(tag: Tag) extends Table[FileRow](tag, "file") {
-  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def id = column[UUID]("id", O.PrimaryKey, O.AutoInc)
   def path = column[String]("path")
   def consignmentId = column[Int]("consignment_id")
   def fileSize = column[Int]("file_size")

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileFormatDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileFormatDao.scala
@@ -1,5 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.core.db.dao
 
+import java.util.UUID
+
 import slick.lifted.Tag
 import slick.jdbc.PostgresProfile.api._
 import uk.gov.nationalarchives.tdr.api.core.db.DbConnection
@@ -15,11 +17,11 @@ class FileFormatDao(implicit val executionContext: ExecutionContext) {
   private val insertQuery = fileFormats returning fileFormats.map(_.id) into ((fileFormat, id) => fileFormat.copy(id = Some(id)))
 
 
-  def getByFileId(fileId: Int): Future[Option[FileFormat]] = {
+  def getByFileId(fileId: UUID): Future[Option[FileFormat]] = {
     db.run(fileFormats.filter(_.fileId === fileId).result).map(_.headOption)
   }
 
-  def createOrUpdate(pronomId: String, fileId: Int) = {
+  def createOrUpdate(pronomId: String, fileId: UUID) = {
     getByFileId(fileId).map(fileFormat => {
       if(fileFormat.isEmpty) {
         val fileFormat: FileFormat = FileFormat(null, pronomId, fileId)
@@ -41,7 +43,7 @@ object FileFormatDao {
 class FileFormatTable(tag: Tag) extends Table[FileFormat](tag, "file_format") {
   def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
   def pronomId = column[String]("pronom_id")
-  def fileId = column[Int]("file_id")
+  def fileId = column[UUID]("file_id")
   def file = foreignKey("file_format_file_fk", fileId, files)(_.id)
 
   override def * = (id.?, pronomId, fileId).mapTo[FileFormat]

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileFormat.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileFormat.scala
@@ -1,4 +1,6 @@
 package uk.gov.nationalarchives.tdr.api.core.db.model
 
-case class FileFormat(id: Option[Int], pronomId: String, fileId: Int)
+import java.util.UUID
+
+case class FileFormat(id: Option[Int], pronomId: String, fileId: UUID)
 

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileRow.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileRow.scala
@@ -1,3 +1,5 @@
 package uk.gov.nationalarchives.tdr.api.core.db.model
 
-case class FileRow (id: Option[Int] = None, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: String, fileName: String)
+import java.util.UUID
+
+case class FileRow (id: Option[UUID] = None, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: String, fileName: String)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileStatus.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileStatus.scala
@@ -1,3 +1,5 @@
 package uk.gov.nationalarchives.tdr.api.core.db.model
 
-case class FileStatus(id: Option[Int] = None, fileFormatVerified: Boolean, fileId: Int, clientSideChecksum: String, serverSideChecksum: String, antivirusStatus: String)
+import java.util.UUID
+
+case class FileStatus(id: Option[Int] = None, fileFormatVerified: Boolean, fileId: UUID, clientSideChecksum: String, serverSideChecksum: String, antivirusStatus: String)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileFormatService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileFormatService.scala
@@ -1,16 +1,18 @@
 package uk.gov.nationalarchives.tdr.api.core.graphql.service
 
+import java.util.UUID
+
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileFormatDao
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileFormatService(fileFormatDao: FileFormatDao)(implicit val executionContext: ExecutionContext) {
 
-  def create(pronomId: String, fileId: Int): Future[Boolean] = {
+  def create(pronomId: String, fileId: UUID): Future[Boolean] = {
     fileFormatDao.createOrUpdate(pronomId, fileId).map(_ => true)
   }
 
-  def getByFileId(fileId: Int) = {
+  def getByFileId(fileId: UUID) = {
     fileFormatDao.getByFileId(fileId)
   }
 

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
@@ -1,5 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.core.graphql.service
 
+import java.util.UUID
+
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileDao
 import uk.gov.nationalarchives.tdr.api.core.db.model.FileRow
 import uk.gov.nationalarchives.tdr.api.core.graphql
@@ -22,7 +24,7 @@ class FileService(fileDao: FileDao, fileStatusService: FileStatusService, consig
   }
 
 
-  def get(id: Int) = {
+  def get(id: UUID) = {
     for {
       fileOption <- fileDao.get(id)
       file <- fileOption.map(Future.successful).getOrElse(Future.failed(new Exception))
@@ -36,9 +38,8 @@ class FileService(fileDao: FileDao, fileStatusService: FileStatusService, consig
     )
   }
 
-
   def createMultiple(inputs: Seq[graphql.CreateFileInput]): Future[Seq[File]] = {
-    //TODO: this should be a sql that adds mutliple rows instead of iterating
+    //TODO: this should be a sql that adds multiple rows instead of iterating
     val files = inputs.map(
       input => {
         create(input)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileStatusService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileStatusService.scala
@@ -1,15 +1,16 @@
 package uk.gov.nationalarchives.tdr.api.core.graphql.service
 
+import java.util.UUID
+
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileStatusDao
 import uk.gov.nationalarchives.tdr.api.core.db.model
 import uk.gov.nationalarchives.tdr.api.core.graphql.FileStatus
 
-
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileStatusService(fileStatusDao: FileStatusDao)(implicit val executionContext: ExecutionContext) {
-  def updateServerSideChecksum(id: Int, checksum: String): Future[Boolean] = {
-    fileStatusDao.updateServerSideChecksum(id, checksum).map(a => {
+  def updateServerSideChecksum(fileId: UUID, checksum: String): Future[Boolean] = {
+    fileStatusDao.updateServerSideChecksum(fileId, checksum).map(a => {
       if (a != 1) {
         throw new RuntimeException("Too many or not enough rows")
       }
@@ -17,8 +18,8 @@ class FileStatusService(fileStatusDao: FileStatusDao)(implicit val executionCont
     })
   }
 
-  def updateClientSideChecksum(id: Int, checksum: String): Future[Boolean] = {
-    fileStatusDao.updateClientSideChecksum(id, checksum).map(a => {
+  def updateClientSideChecksum(fileId: UUID, checksum: String): Future[Boolean] = {
+    fileStatusDao.updateClientSideChecksum(fileId, checksum).map(a => {
       if (a != 1) {
         throw new RuntimeException("Too many or not enough rows")
       }
@@ -27,8 +28,8 @@ class FileStatusService(fileStatusDao: FileStatusDao)(implicit val executionCont
   }
 
 
-  def updateVirusCheck(id: Int, virusCheckStatus: String): Future[Boolean] = {
-    fileStatusDao.updateVirusCheckStatus(id, virusCheckStatus).map(a => {
+  def updateVirusCheck(fileId: UUID, virusCheckStatus: String): Future[Boolean] = {
+    fileStatusDao.updateVirusCheckStatus(fileId, virusCheckStatus).map(a => {
       if (a != 1) {
         throw new RuntimeException("Too many or not enough rows")
       }
@@ -36,12 +37,12 @@ class FileStatusService(fileStatusDao: FileStatusDao)(implicit val executionCont
     })
   }
 
-  def create(fileId: Int, clientSideChecksum: String): Future[FileStatus] = {
+  def create(fileId: UUID, clientSideChecksum: String): Future[FileStatus] = {
     fileStatusDao.create(fileId, clientSideChecksum)
       .map(fs => FileStatus(fs.id.get, fs.clientSideChecksum, fs.serverSideChecksum, fs.fileFormatVerified, fs.fileId, fs.antivirusStatus))
   }
 
-  def getByFileId(fileId: Int): Future[Option[model.FileStatus]] = {
+  def getByFileId(fileId: UUID): Future[Option[model.FileStatus]] = {
     fileStatusDao.getByFileId(fileId)
   }
 }

--- a/migrations/sql/V9__Add_uuid_file_ids.sql
+++ b/migrations/sql/V9__Add_uuid_file_ids.sql
@@ -1,0 +1,51 @@
+/**
+  Switch the file table from using numeric IDs to UUIDs, so that files can be given matching UUID names in S3.
+ */
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+ALTER TABLE file
+  ADD COLUMN file_uuid uuid NOT NULL DEFAULT uuid_generate_v1();
+CREATE UNIQUE INDEX unique_file_id ON file (file_uuid);
+
+ALTER TABLE file_format
+  ADD COLUMN file_uuid uuid REFERENCES file (file_uuid);
+ALTER TABLE file_metadata
+  ADD COLUMN file_uuid uuid REFERENCES file (file_uuid);
+ALTER TABLE file_status
+  ADD COLUMN file_uuid uuid REFERENCES file (file_uuid);
+
+UPDATE file_format
+  SET file_uuid = file.file_uuid
+  FROM file
+  WHERE file_format.file_id = file.id;
+UPDATE file_metadata
+  SET file_uuid = file.file_uuid
+  FROM file
+  WHERE file_metadata.file_id = file.id;
+UPDATE file_status
+  SET file_uuid = file.file_uuid
+  FROM file
+  WHERE file_status.file_id = file.id;
+
+ALTER TABLE file_format ALTER COLUMN file_uuid SET NOT NULL;
+ALTER TABLE file_metadata ALTER COLUMN file_uuid SET NOT NULL;
+ALTER TABLE file_status ALTER COLUMN file_uuid SET NOT NULL;
+
+ALTER TABLE file_format DROP COLUMN file_id;
+ALTER TABLE file_metadata DROP COLUMN file_id;
+ALTER TABLE file_status DROP COLUMN file_id;
+
+ALTER TABLE file DROP CONSTRAINT file_pkey;
+ALTER TABLE file ADD CONSTRAINT file_pkey PRIMARY KEY USING INDEX unique_file_id;
+ALTER TABLE file DROP COLUMN id;
+
+ALTER TABLE file_format RENAME COLUMN file_uuid TO file_id;
+ALTER TABLE file_metadata RENAME COLUMN file_uuid TO file_id;
+ALTER TABLE file_status RENAME COLUMN file_uuid TO file_id;
+
+ALTER TABLE file RENAME COLUMN file_uuid TO id;
+
+COMMIT;


### PR DESCRIPTION
Use UUIDs rather than integers to identify files in the DB and in GraphQL requests.

This will make it possible for the frontend to generate a UUID file ID and then upload each file to S3 with a UUID name. This means we won't expose sequential file IDs to the user, which might look confusing if they don't see sequential IDs for their own files.

This is a draft PR for now because it's a breaking change, so we'll need to roll it out at roughly the same time as the client apps. (Though it's just a prototype, so there's no need to make the changes completely backwards-compatible.)