### PR TITLE
Tk support date type

### DIFF
--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.core.db.dao
 
 import java.sql.Timestamp
-import java.time.LocalDateTime
+import java.time.Instant
 import java.util.UUID
 
 import slick.jdbc.PostgresProfile.api._
@@ -36,16 +36,16 @@ object FileDao {
 }
 
 class FileTable(tag: Tag) extends Table[FileRow](tag, "file") {
-  implicit private val dateColumnType = MappedColumnType.base[LocalDateTime, Timestamp](
-    ldt => Timestamp.valueOf(ldt),
-    ts => ts.toLocalDateTime
+  implicit private val dateColumnType = MappedColumnType.base[Instant, Timestamp](
+    i => Timestamp.from(i),
+    ts => ts.toInstant
   )
 
   def id = column[UUID]("id", O.PrimaryKey, O.AutoInc)
   def path = column[String]("path")
   def consignmentId = column[Int]("consignment_id")
   def fileSize = column[Int]("file_size")
-  def lastModifiedDate = column[LocalDateTime]("last_modified_date")
+  def lastModifiedDate = column[Instant]("last_modified_date")
   def fileName = column[String]("file_name")
   def consignment = foreignKey("file_consignment_fk", consignmentId, consignments)(_.id)
 

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
@@ -1,7 +1,8 @@
 package uk.gov.nationalarchives.tdr.api.core.db.dao
 
 import java.sql.Timestamp
-import java.util.{Date, UUID}
+import java.time.LocalDateTime
+import java.util.UUID
 
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{TableQuery, Tag}
@@ -28,7 +29,6 @@ class FileDao(implicit val executionContext: ExecutionContext) {
   def create(file: FileRow): Future[FileRow] = {
     db.run(insertQuery += file)
   }
-
 }
 
 object FileDao {
@@ -36,16 +36,16 @@ object FileDao {
 }
 
 class FileTable(tag: Tag) extends Table[FileRow](tag, "file") {
-  implicit private val dateColumnType = MappedColumnType.base[Date, Timestamp](
-    d => new Timestamp(d.getTime),
-    ts => new Date(ts.getTime)
+  implicit private val dateColumnType = MappedColumnType.base[LocalDateTime, Timestamp](
+    ldt => Timestamp.valueOf(ldt),
+    ts => ts.toLocalDateTime
   )
 
   def id = column[UUID]("id", O.PrimaryKey, O.AutoInc)
   def path = column[String]("path")
   def consignmentId = column[Int]("consignment_id")
   def fileSize = column[Int]("file_size")
-  def lastModifiedDate = column[Date]("last_modified_date")
+  def lastModifiedDate = column[LocalDateTime]("last_modified_date")
   def fileName = column[String]("file_name")
   def consignment = foreignKey("file_consignment_fk", consignmentId, consignments)(_.id)
 

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
@@ -49,5 +49,7 @@ class FileTable(tag: Tag) extends Table[FileRow](tag, "file") {
   def fileName = column[String]("file_name")
   def consignment = foreignKey("file_consignment_fk", consignmentId, consignments)(_.id)
 
+  //mapTo function displaying error in Intellij but not causing any problems with compilation and running
+  //Likely a bug with Intellij error detection
   override def * = (id.?, path, consignmentId, fileSize, lastModifiedDate, fileName).mapTo[FileRow]
 }

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
@@ -13,8 +13,6 @@ import uk.gov.nationalarchives.tdr.api.core.db.model.FileRow
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileDao(implicit val executionContext: ExecutionContext) {
-
-
   private val db = DbConnection.db
 
   private val insertQuery = files returning files.map(_.id) into ((file, id) => file.copy(id = Some(id)))

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
@@ -1,6 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.core.db.dao
 
-import java.util.UUID
+import java.sql.Timestamp
+import java.util.{Date, UUID}
 
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{TableQuery, Tag}
@@ -12,6 +13,8 @@ import uk.gov.nationalarchives.tdr.api.core.db.model.FileRow
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileDao(implicit val executionContext: ExecutionContext) {
+
+
   private val db = DbConnection.db
 
   private val insertQuery = files returning files.map(_.id) into ((file, id) => file.copy(id = Some(id)))
@@ -35,11 +38,16 @@ object FileDao {
 }
 
 class FileTable(tag: Tag) extends Table[FileRow](tag, "file") {
+  implicit private val dateColumnType = MappedColumnType.base[Date, Timestamp](
+    d => new Timestamp(d.getTime),
+    ts => new Date(ts.getTime)
+  )
+
   def id = column[UUID]("id", O.PrimaryKey, O.AutoInc)
   def path = column[String]("path")
   def consignmentId = column[Int]("consignment_id")
   def fileSize = column[Int]("file_size")
-  def lastModifiedDate = column[String]("last_modified_date")
+  def lastModifiedDate = column[Date]("last_modified_date")
   def fileName = column[String]("file_name")
   def consignment = foreignKey("file_consignment_fk", consignmentId, consignments)(_.id)
 

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileRow.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileRow.scala
@@ -1,5 +1,5 @@
 package uk.gov.nationalarchives.tdr.api.core.db.model
 
-import java.util.UUID
+import java.util.{Date, UUID}
 
-case class FileRow (id: Option[UUID] = None, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: String, fileName: String)
+case class FileRow (id: Option[UUID] = None, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: Date, fileName: String)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileRow.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileRow.scala
@@ -1,6 +1,6 @@
 package uk.gov.nationalarchives.tdr.api.core.db.model
 
-import java.time.LocalDateTime
+import java.time.Instant
 import java.util.UUID
 
-case class FileRow (id: Option[UUID] = None, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: LocalDateTime, fileName: String)
+case class FileRow (id: Option[UUID] = None, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: Instant, fileName: String)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileRow.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileRow.scala
@@ -1,5 +1,6 @@
 package uk.gov.nationalarchives.tdr.api.core.db.model
 
-import java.util.{Date, UUID}
+import java.time.LocalDateTime
+import java.util.UUID
 
-case class FileRow (id: Option[UUID] = None, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: Date, fileName: String)
+case class FileRow (id: Option[UUID] = None, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: LocalDateTime, fileName: String)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
@@ -68,16 +68,9 @@ object GraphQlTypes {
     }
   )
 
-  /* implicit val TimestampType = ScalarAlias[String, Date](DateType,
-    toScalar = date => parseDate(s)
-    fromScala =
-  )*/
-
   implicit private val SeriesType: ObjectType[Unit, Series] = deriveObjectType[Unit, Series]()
   implicit private val ConsignmentType: ObjectType[Unit, Consignment] = deriveObjectType[Unit, Consignment]()
-  implicit private val FileType: ObjectType[Unit, File] = deriveObjectType[Unit, File](
-    //ReplaceField("lastModifiedDate", Field("lastModifiedDate", DateType, resolve = _.value.lastModifiedDate))
-  )
+  implicit private val FileType: ObjectType[Unit, File] = deriveObjectType[Unit, File]()
   implicit private val FileStatusType: ObjectType[Unit, FileStatus] = deriveObjectType[Unit, FileStatus]()
   implicit private val CreateFileInputType: InputObjectType[CreateFileInput] = deriveInputObjectType[CreateFileInput]()
 

--- a/migrations/sql/V10__Change_file_last_modified_column_date_type.sql
+++ b/migrations/sql/V10__Change_file_last_modified_column_date_type.sql
@@ -2,6 +2,7 @@
   Switch the file table from using string last_modified_dates to timestamp with timezone to store dates correctly.
  */
 
-ALTER TABLE file
-  ALTER COLUMN last_modified_date
-  TYPE TIMESTAMPTZ USING last_modified_date::TIMESTAMPTZ;
+ALTER TABLE file ADD COLUMN placeholder TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE file ALTER COLUMN placeholder SET NOT NULL;
+ALTER TABLE file DROP COLUMN last_modified_date;
+ALTER TABLE file RENAME COLUMN placeholder TO last_modified_date;

--- a/migrations/sql/V10__Change_file_last_modified_column_date_type.sql
+++ b/migrations/sql/V10__Change_file_last_modified_column_date_type.sql
@@ -1,0 +1,7 @@
+/**
+  Switch the file table from using string last_modified_dates to timestamp to store dates correctly.
+ */
+
+ALTER TABLE file
+ALTER COLUMN last_modified_date
+TYPE TIMESTAMP USING last_modified_date::TIMESTAMP;

--- a/migrations/sql/V10__Change_file_last_modified_column_date_type.sql
+++ b/migrations/sql/V10__Change_file_last_modified_column_date_type.sql
@@ -1,7 +1,7 @@
 /**
-  Switch the file table from using string last_modified_dates to timestamp to store dates correctly.
+  Switch the file table from using string last_modified_dates to timestamp with timezone to store dates correctly.
  */
 
 ALTER TABLE file
-ALTER COLUMN last_modified_date
-TYPE TIMESTAMP USING last_modified_date::TIMESTAMP;
+  ALTER COLUMN last_modified_date
+  TYPE TIMESTAMPTZ USING last_modified_date::TIMESTAMPTZ;


### PR DESCRIPTION
Add support for dates (Java 8 Time library) in Sangria to allow storage of date objects (java.sql.Timestamp) in Postgres.
Date conversion defaults to the system time zone. Need consideration whether time zone should be passed in as part of the mutation request from the browser. See here regarding the difference in handling in Postgres between timestamps without and with timezones: http://www.postgresqltutorial.com/postgresql-timestamp/