### PR TITLE
Get files linked to a consignment

### DIFF
--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/GraphQlServer.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/GraphQlServer.scala
@@ -7,7 +7,7 @@ import sangria.marshalling.circe._
 import sangria.parser.QueryParser
 import uk.gov.nationalarchives.tdr.api.core.db.dao._
 import uk.gov.nationalarchives.tdr.api.core.graphql.service._
-import uk.gov.nationalarchives.tdr.api.core.graphql.{GraphQlTypes, RequestContext}
+import uk.gov.nationalarchives.tdr.api.core.graphql.{DeferredResolver, GraphQlTypes, RequestContext}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -30,7 +30,13 @@ object GraphQlServer {
     query match {
       case Success(doc) =>
         val variables = request.variables.getOrElse(Json.obj())
-        Executor.execute(GraphQlTypes.schema, doc, requestContext, operationName = request.operationName, variables = variables)
+        Executor.execute(
+          GraphQlTypes.schema,
+          doc, requestContext,
+          operationName = request.operationName,
+          variables = variables,
+          deferredResolver = new DeferredResolver
+        )
       case Failure(e) =>
         Future.failed(e)
     }

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
@@ -27,6 +27,10 @@ class FileDao(implicit val executionContext: ExecutionContext) {
     db.run(files.filter(_.id === id).result).map(_.headOption)
   }
 
+  def getByConsignment(consignmentId: Int): Future[Seq[FileRow]] = {
+    db.run(files.filter(_.consignmentId === consignmentId).result)
+  }
+
   def create(file: FileRow): Future[FileRow] = {
     db.run(insertQuery += file)
   }

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/DeferredResolver.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/DeferredResolver.scala
@@ -1,0 +1,16 @@
+package uk.gov.nationalarchives.tdr.api.core.graphql
+
+import sangria.execution.deferred.{Deferred, UnsupportedDeferError}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class DeferredResolver extends sangria.execution.deferred.DeferredResolver[RequestContext] {
+  override def resolve(deferred: Vector[Deferred[Any]], context: RequestContext, queryState: Any)(implicit ec: ExecutionContext): Vector[Future[Any]] = {
+    deferred.map {
+      case DeferConsignmentFiles(consignmentId) => context.files.getByConsignment(consignmentId)
+      case other => throw UnsupportedDeferError(other)
+    }
+  }
+}
+
+case class DeferConsignmentFiles(consignmentId: Int) extends Deferred[List[File]]

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
@@ -62,11 +62,21 @@ object GraphQlTypes {
 
   implicit private val SeriesType: ObjectType[Unit, Series] = deriveObjectType[Unit, Series]()
   implicit private val CreateSeriesInputType: InputObjectType[CreateSeriesInput] = deriveInputObjectType[CreateSeriesInput]()
-  implicit private val ConsignmentType: ObjectType[Unit, Consignment] = deriveObjectType[Unit, Consignment]()
   implicit private val FileType: ObjectType[Unit, File] = deriveObjectType[Unit, File]()
   implicit private val FileStatusType: ObjectType[Unit, FileStatus] = deriveObjectType[Unit, FileStatus]()
   implicit private val CreateFileInputType: InputObjectType[CreateFileInput] = deriveInputObjectType[CreateFileInput]()
   implicit private val FileCheckStatusType: ObjectType[Unit, FileCheckStatus] = deriveObjectType[Unit, FileCheckStatus]()
+
+  implicit private val ConsignmentType: ObjectType[Unit, Consignment] = ObjectType(
+    "Consignment",
+    fields[Unit, Consignment](
+      Field("id", IntType, resolve = _.value.id),
+      Field("name", StringType, resolve = _.value.name),
+      Field("creator", StringType, resolve = _.value.creator),
+      Field("transferringBody", StringType, resolve = _.value.transferringBody),
+      Field("series", SeriesType, resolve = _.value.series),
+    )
+  )
 
   private val ConsignmentNameArg = Argument("name", StringType)
   private val ConsignmentIdArg = Argument("id", IntType)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
@@ -75,6 +75,11 @@ object GraphQlTypes {
       Field("creator", StringType, resolve = _.value.creator),
       Field("transferringBody", StringType, resolve = _.value.transferringBody),
       Field("series", SeriesType, resolve = _.value.series),
+      Field(
+        "files",
+        ListType(FileType),
+        resolve = context => DeferConsignmentFiles(context.value.id)
+      )
     )
   )
 


### PR DESCRIPTION
Add `files` field to consignment endpoints, which allow you clients to get all the files associated with a consignment. This will be used by the export step, which will fetch all the file details in order to rename them from UUIDs to their original paths.

Fetch files with a DeferredResolver, which only gets the file data if it is requested.

This field should be paginated in future. This unpaginated field should let us test the export process, and we can add pagination if/when we need it.