### PR TITLE
Allow all File queries to include file status details

### DIFF
--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileFormatDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileFormatDao.scala
@@ -2,12 +2,12 @@ package uk.gov.nationalarchives.tdr.api.core.db.dao
 
 import java.util.UUID
 
-import slick.lifted.Tag
 import slick.jdbc.PostgresProfile.api._
+import slick.lifted.Tag
 import uk.gov.nationalarchives.tdr.api.core.db.DbConnection
-import uk.gov.nationalarchives.tdr.api.core.db.model.{FileFormat, FileRow}
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileDao.files
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileFormatDao.fileFormats
+import uk.gov.nationalarchives.tdr.api.core.db.model.FileFormatRow
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -17,14 +17,14 @@ class FileFormatDao(implicit val executionContext: ExecutionContext) {
   private val insertQuery = fileFormats returning fileFormats.map(_.id) into ((fileFormat, id) => fileFormat.copy(id = Some(id)))
 
 
-  def getByFileId(fileId: UUID): Future[Option[FileFormat]] = {
+  def getByFileId(fileId: UUID): Future[Option[FileFormatRow]] = {
     db.run(fileFormats.filter(_.fileId === fileId).result).map(_.headOption)
   }
 
   def createOrUpdate(pronomId: String, fileId: UUID) = {
     getByFileId(fileId).map(fileFormat => {
       if(fileFormat.isEmpty) {
-        val fileFormat: FileFormat = FileFormat(null, pronomId, fileId)
+        val fileFormat: FileFormatRow = FileFormatRow(null, pronomId, fileId)
         db.run(insertQuery += fileFormat)
       } else {
         val q = for { c <- fileFormats if c.fileId === fileId } yield c.pronomId
@@ -40,11 +40,11 @@ object FileFormatDao {
   val fileFormats = TableQuery[FileFormatTable]
 }
 
-class FileFormatTable(tag: Tag) extends Table[FileFormat](tag, "file_format") {
+class FileFormatTable(tag: Tag) extends Table[FileFormatRow](tag, "file_format") {
   def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
   def pronomId = column[String]("pronom_id")
   def fileId = column[UUID]("file_id")
   def file = foreignKey("file_format_file_fk", fileId, files)(_.id)
 
-  override def * = (id.?, pronomId, fileId).mapTo[FileFormat]
+  override def * = (id.?, pronomId, fileId).mapTo[FileFormatRow]
 }

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileStatusDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileStatusDao.scala
@@ -5,11 +5,10 @@ import java.util.UUID
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.Tag
 import uk.gov.nationalarchives.tdr.api.core.db.DbConnection
-import uk.gov.nationalarchives.tdr.api.core.db.dao.ConsignmentDao.consignments
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileDao.files
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileFormatDao.fileFormats
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileStatusDao.fileStatuses
-import uk.gov.nationalarchives.tdr.api.core.db.model.{FileRow, FileStatus}
+import uk.gov.nationalarchives.tdr.api.core.db.model.{FileRow, FileStatusRow}
 import uk.gov.nationalarchives.tdr.api.core.graphql.FileCheckStatus
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -23,20 +22,20 @@ class FileStatusDao(implicit val executionContext: ExecutionContext) {
 
   private val insert = fileStatuses returning fileStatuses.map(_.id) into ((fileStatus, id) => fileStatus.copy(id = Some(id)))
 
-  def create(fileId: UUID, clientSideChecksum: String): Future[FileStatus] = {
-    val fileStatus = FileStatus(None, false, fileId, clientSideChecksum, "", "")
+  def create(fileId: UUID, clientSideChecksum: String): Future[FileStatusRow] = {
+    val fileStatus = FileStatusRow(None, false, fileId, clientSideChecksum, "", "")
     db.run(insert += fileStatus)
   }
 
-  def createMultiple(fileStatusRows: Seq[FileStatus]): Future[Seq[FileStatus]] = {
+  def createMultiple(fileStatusRows: Seq[FileStatusRow]): Future[Seq[FileStatusRow]] = {
     db.run(insert ++= fileStatusRows)
   }
 
-  def get(id: Int): Future[Option[FileStatus]] = {
+  def get(id: Int): Future[Option[FileStatusRow]] = {
     db.run(fileStatuses.filter(_.id === id).result).map(_.headOption)
   }
 
-  def getByFileId(fileId: UUID): Future[Option[FileStatus]] = {
+  def getByFileId(fileId: UUID): Future[Option[FileStatusRow]] = {
     db.run(fileStatuses.filter(_.fileId === fileId).result).map(_.headOption)
   }
 
@@ -98,7 +97,7 @@ object FileStatusDao {
   val fileStatuses = TableQuery[FileStatusTable]
 }
 
-class FileStatusTable(tag: Tag) extends Table[FileStatus](tag, "file_status") {
+class FileStatusTable(tag: Tag) extends Table[FileStatusRow](tag, "file_status") {
   def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
   def fileFormatVerified = column[Boolean]("file_format_verified")
   def fileId = column[UUID]("file_id")
@@ -107,5 +106,5 @@ class FileStatusTable(tag: Tag) extends Table[FileStatus](tag, "file_status") {
   def antivirus_status = column[String]("antivirus_status")
   def file = foreignKey("file_file_status_fk", fileId, files)(_.id)
 
-  override def * = (id.?, fileFormatVerified, fileId, clientSideChecksum, serverSideChecksum, antivirus_status).mapTo[FileStatus]
+  override def * = (id.?, fileFormatVerified, fileId, clientSideChecksum, serverSideChecksum, antivirus_status).mapTo[FileStatusRow]
 }

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileFormatRow.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileFormatRow.scala
@@ -2,5 +2,5 @@ package uk.gov.nationalarchives.tdr.api.core.db.model
 
 import java.util.UUID
 
-case class FileFormat(id: Option[Int], pronomId: String, fileId: UUID)
+case class FileFormatRow(id: Option[Int], pronomId: String, fileId: UUID)
 

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileStatus.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileStatus.scala
@@ -1,5 +1,0 @@
-package uk.gov.nationalarchives.tdr.api.core.db.model
-
-import java.util.UUID
-
-case class FileStatus(id: Option[Int] = None, fileFormatVerified: Boolean, fileId: UUID, clientSideChecksum: String, serverSideChecksum: String, antivirusStatus: String)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileStatusRow.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileStatusRow.scala
@@ -1,0 +1,5 @@
+package uk.gov.nationalarchives.tdr.api.core.db.model
+
+import java.util.UUID
+
+case class FileStatusRow(id: Option[Int] = None, fileFormatVerified: Boolean, fileId: UUID, clientSideChecksum: String, serverSideChecksum: String, antivirusStatus: String)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/DeferredResolver.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/DeferredResolver.scala
@@ -1,5 +1,7 @@
 package uk.gov.nationalarchives.tdr.api.core.graphql
 
+import java.util.UUID
+
 import sangria.execution.deferred.{Deferred, UnsupportedDeferError}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -8,9 +10,11 @@ class DeferredResolver extends sangria.execution.deferred.DeferredResolver[Reque
   override def resolve(deferred: Vector[Deferred[Any]], context: RequestContext, queryState: Any)(implicit ec: ExecutionContext): Vector[Future[Any]] = {
     deferred.map {
       case DeferConsignmentFiles(consignmentId) => context.files.getByConsignment(consignmentId)
+      case DeferFileStatus(fileId) => context.fileStatuses.getByFileId(fileId).map(status => status.get)
       case other => throw UnsupportedDeferError(other)
     }
   }
 }
 
 case class DeferConsignmentFiles(consignmentId: Int) extends Deferred[List[File]]
+case class DeferFileStatus(fileId: UUID) extends Deferred[FileStatus]

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
@@ -62,11 +62,23 @@ object GraphQlTypes {
 
   implicit private val SeriesType: ObjectType[Unit, Series] = deriveObjectType[Unit, Series]()
   implicit private val CreateSeriesInputType: InputObjectType[CreateSeriesInput] = deriveInputObjectType[CreateSeriesInput]()
-  implicit private val FileType: ObjectType[Unit, File] = deriveObjectType[Unit, File]()
   implicit private val FileStatusType: ObjectType[Unit, FileStatus] = deriveObjectType[Unit, FileStatus]()
   implicit private val CreateFileInputType: InputObjectType[CreateFileInput] = deriveInputObjectType[CreateFileInput]()
   implicit private val FileCheckStatusType: ObjectType[Unit, FileCheckStatus] = deriveObjectType[Unit, FileCheckStatus]()
 
+  implicit private val FileType: ObjectType[Unit, File] = ObjectType(
+    "File",
+    fields[Unit, File](
+      Field("id", UuidType, resolve = _.value.id),
+      Field("path", StringType, resolve = _.value.path),
+      Field("consignmentId", IntType, resolve = _.value.consignmentId),
+      Field("fileStatus", FileStatusType, resolve = _.value.fileStatus),
+      Field("pronomId", OptionType(StringType), resolve = _.value.pronomId),
+      Field("fileSize", IntType, resolve = _.value.fileSize),
+      Field("lastModifiedDate", InstantType, resolve = _.value.lastModifiedDate),
+      Field("fileName", StringType, resolve = _.value.fileName),
+    )
+  )
   implicit private val ConsignmentType: ObjectType[Unit, Consignment] = ObjectType(
     "Consignment",
     fields[Unit, Consignment](

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
@@ -72,7 +72,11 @@ object GraphQlTypes {
       Field("id", UuidType, resolve = _.value.id),
       Field("path", StringType, resolve = _.value.path),
       Field("consignmentId", IntType, resolve = _.value.consignmentId),
-      Field("fileStatus", FileStatusType, resolve = _.value.fileStatus),
+      Field(
+        "fileStatus",
+        FileStatusType,
+        resolve = context => DeferFileStatus(context.value.id)
+      ),
       Field("pronomId", OptionType(StringType), resolve = _.value.pronomId),
       Field("fileSize", IntType, resolve = _.value.fileSize),
       Field("lastModifiedDate", InstantType, resolve = _.value.lastModifiedDate),

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
@@ -1,10 +1,8 @@
 package uk.gov.nationalarchives.tdr.api.core.graphql.service
-
 import java.util.UUID
 
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileDao
-import uk.gov.nationalarchives.tdr.api.core.db.model
-import uk.gov.nationalarchives.tdr.api.core.db.model.FileRow
+import uk.gov.nationalarchives.tdr.api.core.db.model.{FileRow, FileStatusRow}
 import uk.gov.nationalarchives.tdr.api.core.graphql
 import uk.gov.nationalarchives.tdr.api.core.graphql.{CreateFileInput, File, FileStatus}
 
@@ -41,16 +39,16 @@ class FileService(fileDao: FileDao, fileStatusService: FileStatusService, consig
       fileStatuses <- fileStatusService.createMutiple(pathToInput, result)
     } yield {
 
-      val fileIdToStatus: Map[UUID, model.FileStatus] = fileStatuses.groupBy(_.fileId).mapValues(_.head)
+      val fileIdToStatus: Map[UUID, FileStatusRow] = fileStatuses.groupBy(_.fileId).mapValues(_.head)
       result.map(r => {
-        val fileStatus: model.FileStatus = fileIdToStatus(r.id.get)
+        val fileStatus: FileStatusRow = fileIdToStatus(r.id.get)
         getFileReturnValue(r, fileStatus)
       }
       )
     }
   }
 
-  private def getFileReturnValue(r: FileRow, fileStatus: model.FileStatus) = {
+  private def getFileReturnValue(r: FileRow, fileStatus: FileStatusRow) = {
     val returnFileStatus = FileStatus(fileStatus.id.get, fileStatus.clientSideChecksum, fileStatus.serverSideChecksum, fileStatus.fileFormatVerified, r.id.get, fileStatus.antivirusStatus)
     File(r.id.get,
       r.path,

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
@@ -36,7 +36,7 @@ class FileService(fileDao: FileDao, fileStatusService: FileStatusService, consig
 
     for {
       result <- fileDao.createMultiple(inputs)
-      fileStatuses <- fileStatusService.createMutiple(pathToInput, result)
+      fileStatuses <- fileStatusService.createMultiple(pathToInput, result)
     } yield {
 
       val fileIdToStatus: Map[UUID, FileStatusRow] = fileStatuses.groupBy(_.fileId).mapValues(_.head)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileService.scala
@@ -20,11 +20,10 @@ class FileService(fileDao: FileDao, fileStatusService: FileStatusService, consig
     for {
       fileOption <- fileDao.get(id)
       file <- fileOption.map(Future.successful).getOrElse(Future.failed(new Exception))
-      fileStatusOption <- fileStatusService.getByFileId(fileOption.get.id.get)
-      fileStatus <- fileStatusOption.map(Future.successful).getOrElse(Future.failed(new Exception))
+      fileStatus <- fileStatusService.getByFileId(fileOption.get.id.get)
       fileFormat <- fileFormatService.getByFileId(file.id.get)
     } yield File(file.id.get, file.path, file.consignmentId,
-      FileStatus(fileStatus.id.get, fileStatus.clientSideChecksum, fileStatus.serverSideChecksum, fileStatus.fileFormatVerified, fileStatus.fileId, fileStatus.antivirusStatus),
+      fileStatus.get,
       fileFormat.map(_.pronomId)
       , file.fileSize, file.lastModifiedDate, file.fileName
     )

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileStatusService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileStatusService.scala
@@ -4,20 +4,17 @@ import java.util.UUID
 
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileStatusDao
 import uk.gov.nationalarchives.tdr.api.core.db.model
-import uk.gov.nationalarchives.tdr.api.core.db.model.{FileRow, FileStatus}
-import uk.gov.nationalarchives.tdr.api.core.graphql.{CreateFileInput, FileCheckStatus}
+import uk.gov.nationalarchives.tdr.api.core.db.model.FileRow
+import uk.gov.nationalarchives.tdr.api.core.graphql.{CreateFileInput, FileCheckStatus, FileStatus}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileStatusService(fileStatusDao: FileStatusDao)(implicit val executionContext: ExecutionContext) {
 
-
-  def createMutiple(pathToInput: Map[String, CreateFileInput], result: Seq[FileRow]): Future[Seq[FileStatus]] = {
+  def createMutiple(pathToInput: Map[String, CreateFileInput], result: Seq[FileRow]): Future[Seq[model.FileStatus]] = {
     val fileStatusRows = result.map(r => model.FileStatus(None, false, r.id.get, pathToInput(r.path).clientSideChecksum, "", ""))
     fileStatusDao.createMultiple(fileStatusRows)
   }
-
-
 
   def updateServerSideChecksum(fileId: UUID, checksum: String): Future[Boolean] = {
     fileStatusDao.updateServerSideChecksum(fileId, checksum).map(a => {
@@ -51,11 +48,13 @@ class FileStatusService(fileStatusDao: FileStatusDao)(implicit val executionCont
     })
   }
 
-  def create(fileId: UUID, clientSideChecksum: String): Future[FileStatus] = {
+  def create(fileId: UUID, clientSideChecksum: String): Future[model.FileStatus] = {
     fileStatusDao.create(fileId, clientSideChecksum)
   }
 
-  def getByFileId(fileId: UUID): Future[Option[model.FileStatus]] = {
-    fileStatusDao.getByFileId(fileId)
+  def getByFileId(fileId: UUID): Future[Option[FileStatus]] = {
+    fileStatusDao.getByFileId(fileId).map(_.map(fileStatus =>
+      FileStatus(fileStatus.id.get, fileStatus.clientSideChecksum, fileStatus.serverSideChecksum, fileStatus.fileFormatVerified, fileStatus.fileId, fileStatus.antivirusStatus)
+    ))
   }
 }

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileStatusService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileStatusService.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class FileStatusService(fileStatusDao: FileStatusDao)(implicit val executionContext: ExecutionContext) {
 
-  def createMutiple(pathToInput: Map[String, CreateFileInput], result: Seq[FileRow]): Future[Seq[FileStatusRow]] = {
+  def createMultiple(pathToInput: Map[String, CreateFileInput], result: Seq[FileRow]): Future[Seq[FileStatusRow]] = {
     val fileStatusRows = result.map(r => FileStatusRow(None, false, r.id.get, pathToInput(r.path).clientSideChecksum, "", ""))
     fileStatusDao.createMultiple(fileStatusRows)
   }

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileStatusService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/FileStatusService.scala
@@ -3,16 +3,15 @@ package uk.gov.nationalarchives.tdr.api.core.graphql.service
 import java.util.UUID
 
 import uk.gov.nationalarchives.tdr.api.core.db.dao.FileStatusDao
-import uk.gov.nationalarchives.tdr.api.core.db.model
-import uk.gov.nationalarchives.tdr.api.core.db.model.FileRow
+import uk.gov.nationalarchives.tdr.api.core.db.model.{FileRow, FileStatusRow}
 import uk.gov.nationalarchives.tdr.api.core.graphql.{CreateFileInput, FileCheckStatus, FileStatus}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileStatusService(fileStatusDao: FileStatusDao)(implicit val executionContext: ExecutionContext) {
 
-  def createMutiple(pathToInput: Map[String, CreateFileInput], result: Seq[FileRow]): Future[Seq[model.FileStatus]] = {
-    val fileStatusRows = result.map(r => model.FileStatus(None, false, r.id.get, pathToInput(r.path).clientSideChecksum, "", ""))
+  def createMutiple(pathToInput: Map[String, CreateFileInput], result: Seq[FileRow]): Future[Seq[FileStatusRow]] = {
+    val fileStatusRows = result.map(r => FileStatusRow(None, false, r.id.get, pathToInput(r.path).clientSideChecksum, "", ""))
     fileStatusDao.createMultiple(fileStatusRows)
   }
 
@@ -48,7 +47,7 @@ class FileStatusService(fileStatusDao: FileStatusDao)(implicit val executionCont
     })
   }
 
-  def create(fileId: UUID, clientSideChecksum: String): Future[model.FileStatus] = {
+  def create(fileId: UUID, clientSideChecksum: String): Future[FileStatusRow] = {
     fileStatusDao.create(fileId, clientSideChecksum)
   }
 


### PR DESCRIPTION
Add a deferred resolver to the `fileStatus` field on `File`. This means that any endpoint which returns a `File` (even when it's nested) can include nested `fileStatus` queries. Before, you could only query `fileStatus` on the `getFile` endpoint.

This will let us get the file status in the export task, since it gets file details through the `getConsignment` endpoint.

Probably easiest to review commit-by-commit, since some of the commits are refactorings.