### PR TITLE
Add 'confirmTransfer' endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ To use the schema in Postman, see the [Postman guide to importing GraphQL schema
 
 [postman-import-graphql]: https://learning.getpostman.com/docs/postman/sending_api_requests/graphql/#importing-graphql-schemas
 
+### Trigger consignment export
+
+Since the consignment export runs in ECS, it has no way to access your local database. So by default, the API does not
+trigger the export task in development.
+
+If you want to enable it anyway (though it will try to export a consignment) set these environment variables when you
+run the API:
+
+- `EXPORT_TASK_ID`: the ID of the ECS task, e.g. `tdr-consignment-export-dev`
+- `EXPORT_CLUSTER_ARN`: the ARN of the ECS cluster
+- `EXPORT_SUBNET_ID`: the ID of the subnet in the VPC to run the task in
+- `EXPORT_SECURITY_GROUP_ID`: the ID of the security group that the task should use. It must have permission to pull the
+  Docker image, and it must be in same VPC as the subnet you specified earlier
+- `EXPORT_CONTAINER_ID` the ID of the container in ECS, e.g. `consignment-export-dev`
+
 ## Deployment
 
 ### Infrastructure

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ ThisBuild / version := "0.1.0-SNAPSHOT"
 
 lazy val akkaHttpVersion = "10.1.9"
 lazy val akkaVersion    = "2.6.0-M5"
+lazy val awsSdkVersion = "2.9.11"
 
 enablePlugins(GraphQLSchemaPlugin)
 
@@ -20,7 +21,8 @@ lazy val core = (project in file("core"))
       "org.slf4j" % "slf4j-nop" % "1.7.26",
       "com.typesafe.slick" %% "slick-hikaricp" % "3.3.1",
       "org.postgresql" % "postgresql" % "42.2.6",
-      "software.amazon.awssdk" % "ssm" % "2.7.23",
+      "software.amazon.awssdk" % "ecs" % awsSdkVersion,
+      "software.amazon.awssdk" % "ssm" % awsSdkVersion,
       "io.circe" %% "circe-generic" % "0.9.3",
     )
   )

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/backgroundtask/ConsignmentExport.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/backgroundtask/ConsignmentExport.scala
@@ -1,0 +1,50 @@
+package uk.gov.nationalarchives.tdr.api.core.db.backgroundtask
+
+import software.amazon.awssdk.services.ecs.EcsClient
+import software.amazon.awssdk.services.ecs.model._
+
+object ConsignmentExport {
+
+  private val ecsClient = EcsClient.create
+
+  def startExport(consignmentId: Int): Unit = {
+    // In Beta, the API should be decoupled from the export task using SNS as an intermediary. But that requires
+    // extra configuration and a Lambda layer to trigger ECS, so in Alpha we start the task in ECS directly.
+
+    val taskNameParam = sys.env.get("EXPORT_TASK_ID")
+
+    taskNameParam match {
+      case Some(taskId) => startExportTask(taskId, consignmentId)
+      case None => println("No export task configured in EXPORT_TASK_ID, so skipping export")
+    }
+  }
+
+  private def startExportTask(taskId: String, consignmentId: Int): Unit = {
+    val clusterArn = sys.env("EXPORT_CLUSTER_ARN")
+    val securityGroupId = sys.env("EXPORT_SECURITY_GROUP_ID")
+    val subnetId = sys.env("EXPORT_SUBNET_ID")
+    val containerId = sys.env("EXPORT_CONTAINER_ID")
+
+    val awsVpcConfiguration = AwsVpcConfiguration.builder()
+      .securityGroups(securityGroupId)
+      .subnets(subnetId)
+      .build
+    val networkConfiguration = NetworkConfiguration.builder()
+      .awsvpcConfiguration(awsVpcConfiguration)
+      .build
+    val consignmentIdParam = KeyValuePair.builder.name("CONSIGNMENT_ID").value(consignmentId.toString).build
+    val containerOverride = ContainerOverride.builder
+      .name(containerId)
+      .environment(consignmentIdParam)
+      .build
+    val taskOverride = TaskOverride.builder.containerOverrides(containerOverride).build
+    val runTaskRequest = RunTaskRequest.builder
+      .taskDefinition(taskId)
+      .launchType(LaunchType.FARGATE)
+      .cluster(clusterArn)
+      .networkConfiguration(networkConfiguration)
+      .overrides(taskOverride)
+      .build
+    ecsClient.runTask(runTaskRequest)
+  }
+}

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/ConsignmentRow.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/ConsignmentRow.scala
@@ -1,3 +1,10 @@
 package uk.gov.nationalarchives.tdr.api.core.db.model
 
-case class ConsignmentRow(id: Option[Int] = None, name: String, seriesId: Int, creator:String, transferringBody:String)
+case class ConsignmentRow(
+                           id: Option[Int] = None,
+                           name: String,
+                           progress: String,
+                           seriesId: Int,
+                           creator: String,
+                           transferringBody: String
+                         )

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
@@ -303,6 +303,12 @@ object GraphQlTypes {
       OptionType(PasswordResetType),
       arguments = List(EmailArg),
       resolve = ctx => ctx.ctx.users.createResetPasswordToken(ctx.arg(EmailArg))
+    ),
+    Field(
+      "confirmTransfer",
+      BooleanType,
+      arguments = List(ConsignmentIdArg),
+      resolve = ctx => ctx.ctx.consignments.confirmTransfer(ctx.arg(ConsignmentIdArg))
     )
   ))
 

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/ConsignmentService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/ConsignmentService.scala
@@ -35,7 +35,7 @@ class ConsignmentService(consignmentDao: ConsignmentDao, seriesService: SeriesSe
   }
 
   def create(name: String, seriesId: Int, creator: String, transferringBody: String): Future[Consignment] = {
-    val newConsignment = ConsignmentRow(None, name, seriesId, creator, transferringBody)
+    val newConsignment = ConsignmentRow(None, name, "NEW", seriesId, creator, transferringBody)
     val result = consignmentDao.create(newConsignment)
 
     result.flatMap(persistedConsignment =>
@@ -44,5 +44,10 @@ class ConsignmentService(consignmentDao: ConsignmentDao, seriesService: SeriesSe
           persistedConsignment.creator, persistedConsignment.transferringBody)
       )
     )
+  }
+
+  def confirmTransfer(consignmentId: Int): Future[Boolean] = {
+    consignmentDao.updateProgress(consignmentId, "CONFIRMED")
+      .map(_ => true)
   }
 }

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/ConsignmentService.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/service/ConsignmentService.scala
@@ -1,5 +1,6 @@
 package uk.gov.nationalarchives.tdr.api.core.graphql.service
 
+import uk.gov.nationalarchives.tdr.api.core.db.backgroundtask.ConsignmentExport
 import uk.gov.nationalarchives.tdr.api.core.db.dao.ConsignmentDao
 import uk.gov.nationalarchives.tdr.api.core.db.model.ConsignmentRow
 import uk.gov.nationalarchives.tdr.api.core.graphql.{Consignment, Series}
@@ -48,6 +49,9 @@ class ConsignmentService(consignmentDao: ConsignmentDao, seriesService: SeriesSe
 
   def confirmTransfer(consignmentId: Int): Future[Boolean] = {
     consignmentDao.updateProgress(consignmentId, "CONFIRMED")
-      .map(_ => true)
+      .map(_ => {
+        ConsignmentExport.startExport(consignmentId)
+        true
+      })
   }
 }

--- a/migrations/sql/V12__User_password_table.sql
+++ b/migrations/sql/V12__User_password_table.sql
@@ -9,7 +9,7 @@ last_name varchar(255),
 email varchar(255),
 provider_id varchar(255) not null,
 provider_key varchar(255) not null
-)
+);
 
 create table password_reset_token (
 email varchar(255) primary key,

--- a/migrations/sql/V13__Add_consignment_progress.sql
+++ b/migrations/sql/V13__Add_consignment_progress.sql
@@ -1,0 +1,2 @@
+ALTER TABLE consignments
+    ADD COLUMN progress VARCHAR (50) NOT NULL DEFAULT ('NEW');


### PR DESCRIPTION
Add migration which confirms that a consignment is ready to transfer.

It updates a new `progress` column in the consignments table, and triggers the export task in ECS.

In Beta, the export task should be decoupled from the API using SNS as an intermediary. This will remove all the ECS configuration from the API, and will let us add retry logic if an export fails. But that needs extra infrastructure, so for now just trigger the task from the API to keep the prototype simple.