### PR TITLE
Support multi-gigabyte file sizes

### DIFF
--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/dao/FileDao.scala
@@ -54,7 +54,7 @@ class FileTable(tag: Tag) extends Table[FileRow](tag, "file") {
   def id = column[UUID]("id", O.PrimaryKey, O.AutoInc)
   def path = column[String]("path")
   def consignmentId = column[Int]("consignment_id")
-  def fileSize = column[Int]("file_size")
+  def fileSize = column[Long]("file_size")
   def lastModifiedDate = column[Instant]("last_modified_date")
   def fileName = column[String]("file_name")
   def consignment = foreignKey("file_consignment_fk", consignmentId, consignments)(_.id)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileRow.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/model/FileRow.scala
@@ -3,4 +3,4 @@ package uk.gov.nationalarchives.tdr.api.core.db.model
 import java.time.Instant
 import java.util.UUID
 
-case class FileRow (id: Option[UUID] = None, path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: Instant, fileName: String)
+case class FileRow (id: Option[UUID] = None, path: String, consignmentId: Int, fileSize: Long, lastModifiedDate: Instant, fileName: String)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/graphql/GraphQlTypes.scala
@@ -9,7 +9,7 @@ import io.circe.generic.auto._
 import sangria.ast.StringValue
 import sangria.macros.derive._
 import sangria.marshalling.circe._
-import sangria.schema.{Argument, BooleanType, Field, InputObjectType, IntType, ListInputType, ListType, ObjectType, OptionType, ScalarType, Schema, StringType, fields}
+import sangria.schema.{Argument, BooleanType, Field, InputObjectType, IntType, ListInputType, ListType, LongType, ObjectType, OptionType, ScalarType, Schema, StringType, fields}
 import sangria.validation.ValueCoercionViolation
 
 import scala.util.{Failure, Success, Try}
@@ -87,7 +87,7 @@ object GraphQlTypes {
         resolve = context => DeferFileStatus(context.value.id)
       ),
       Field("pronomId", OptionType(StringType), resolve = _.value.pronomId),
-      Field("fileSize", IntType, resolve = _.value.fileSize),
+      Field("fileSize", LongType, resolve = _.value.fileSize),
       Field("lastModifiedDate", InstantType, resolve = _.value.lastModifiedDate),
       Field("fileName", StringType, resolve = _.value.fileName),
     )
@@ -321,8 +321,8 @@ case class Consignment(id: Int, name: String, series: Series, creator: String, t
 case class FileStatus(id: Int, clientSideChecksum: String, serverSideChecksum: String, fileFormatVerified: Boolean, fileId: UUID, antivirusStatus: String)
 //TODO: need to define a custom scalar date type to store dates in DB
 
-case class File(id: UUID, path: String, consignmentId: Int, fileStatus: FileStatus, pronomId: Option[String], fileSize: Int, lastModifiedDate: Instant, fileName: String)
-case class CreateFileInput(path: String, consignmentId: Int, fileSize: Int, lastModifiedDate: Instant, fileName: String, clientSideChecksum: String)
+case class File(id: UUID, path: String, consignmentId: Int, fileStatus: FileStatus, pronomId: Option[String], fileSize: Long, lastModifiedDate: Instant, fileName: String)
+case class CreateFileInput(path: String, consignmentId: Int, fileSize: Long, lastModifiedDate: Instant, fileName: String, clientSideChecksum: String)
 case class FileCheckStatus(percentage: Int, totalFiles: Int, virusErrors: List[String], checksumErrors: List[String])
 case class ConsignmentInput(name: String, series: Series, creator: String, transferringBody:String)
 case class User(id: Int, firstName: String, lastName: String, email: String, providerId: String, providerKey: String)

--- a/migrations/sql/V14__Convert_file_size_to_bigint.sql
+++ b/migrations/sql/V14__Convert_file_size_to_bigint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE file
+    ALTER COLUMN file_size TYPE BIGINT;


### PR DESCRIPTION
Convert the type of the fileSize property from Int to BigInt (in the DB) or Long (in the Scala code). This will let the API accept larger file sizes.