### PR TITLE
Use connection pool to connect to PostgreSQL DB

### DIFF
--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/DbConnection.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/DbConnection.scala
@@ -4,15 +4,15 @@ import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import slick.jdbc.PostgresProfile.api._
 
 object DbConnection {
-  private val dbConfig = sys.env.get("TDR_API_ENVIRONMENT") match {
+  private val connectionParameters = sys.env.get("TDR_API_ENVIRONMENT") match {
     case Some("TEST") => PrototypeDbConfig
     case _ => DevDbConfig
   }
 
-  private val config = ConfigFactory.empty()
-    .withValue("db.url", ConfigValueFactory.fromAnyRef(dbConfig.url))
-    .withValue("db.user", ConfigValueFactory.fromAnyRef(dbConfig.username))
-    .withValue("db.password", ConfigValueFactory.fromAnyRef(dbConfig.password))
+  private val postgresConfig = ConfigFactory.empty()
+    .withValue("db.url", ConfigValueFactory.fromAnyRef(connectionParameters.url))
+    .withValue("db.user", ConfigValueFactory.fromAnyRef(connectionParameters.username))
+    .withValue("db.password", ConfigValueFactory.fromAnyRef(connectionParameters.password))
 
-  val db = Database.forConfig("db", config, new org.postgresql.Driver)
+  val db = Database.forConfig("db", postgresConfig, new org.postgresql.Driver)
 }

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/DbConnection.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/db/DbConnection.scala
@@ -1,21 +1,18 @@
 package uk.gov.nationalarchives.tdr.api.core.db
 
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import slick.jdbc.PostgresProfile.api._
 
 object DbConnection {
-  private val driver = "org.postgresql.Driver"
-  // Load PostgreSQL driver into classpath
-  Class.forName(driver)
-
   private val dbConfig = sys.env.get("TDR_API_ENVIRONMENT") match {
     case Some("TEST") => PrototypeDbConfig
     case _ => DevDbConfig
   }
 
-  val db = Database.forURL(
-    url = dbConfig.url,
-    user = dbConfig.username,
-    password = dbConfig.password,
-    driver = driver
-  )
+  private val config = ConfigFactory.empty()
+    .withValue("db.url", ConfigValueFactory.fromAnyRef(dbConfig.url))
+    .withValue("db.user", ConfigValueFactory.fromAnyRef(dbConfig.username))
+    .withValue("db.password", ConfigValueFactory.fromAnyRef(dbConfig.password))
+
+  val db = Database.forConfig("db", config, new org.postgresql.Driver)
 }


### PR DESCRIPTION
Create a Slick DB connection using `Database.forConfig` rather than
`Database.forUrl`. Under the surface, this will use
`slick.jdbc.hikaricp.HikariCPJdbcDataSource$` to create a connection
pool, rather than using `DataSourceJdbcDataSource`, which has a
limited number of connections but does not use a pool.

The purpose of this change is to see whether it fixes the
`java.net.ConnectException` which we get when running the export
process for consignments with a large number of files, and which may
be caused by the default data source not managing the connections well.