### PR TITLE
Add prototype consignment metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ ThisBuild / version := "0.1.0-SNAPSHOT"
 
 lazy val akkaHttpVersion = "10.1.9"
 lazy val akkaVersion    = "2.6.0-M5"
-lazy val awsSdkVersion = "2.9.11"
+lazy val awsSdkVersion = "2.10.41"
 
 enablePlugins(GraphQLSchemaPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ lazy val core = (project in file("core"))
       "org.slf4j" % "slf4j-nop" % "1.7.26",
       "com.typesafe.slick" %% "slick-hikaricp" % "3.3.1",
       "org.postgresql" % "postgresql" % "42.2.6",
+      "software.amazon.awssdk" % "cloudwatch" % awsSdkVersion,
       "software.amazon.awssdk" % "ecs" % awsSdkVersion,
       "software.amazon.awssdk" % "ssm" % awsSdkVersion,
       "io.circe" %% "circe-generic" % "0.9.3",

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/GraphQlServer.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/GraphQlServer.scala
@@ -8,6 +8,7 @@ import sangria.parser.QueryParser
 import uk.gov.nationalarchives.tdr.api.core.db.dao._
 import uk.gov.nationalarchives.tdr.api.core.graphql.service._
 import uk.gov.nationalarchives.tdr.api.core.graphql.{DeferredResolver, GraphQlTypes, RequestContext}
+import uk.gov.nationalarchives.tdr.api.core.monitoring.Metrics
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -16,7 +17,9 @@ import scala.util.{Failure, Success, Try}
 object GraphQlServer {
 
   private val seriesService = new SeriesService(new SeriesDao)
-  private val consignmentService = new ConsignmentService(new ConsignmentDao, seriesService)
+  private val consignmentDao = new ConsignmentDao
+  private val metrics = new Metrics(consignmentDao)
+  private val consignmentService = new ConsignmentService(consignmentDao, seriesService, metrics)
   private val fileStatusService = new FileStatusService(new FileStatusDao())
   private val fileFormatService = new FileFormatService(new FileFormatDao())
   private val fileService = new FileService(new FileDao, fileStatusService, consignmentService, fileFormatService)

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/monitoring/Metrics.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/monitoring/Metrics.scala
@@ -1,0 +1,26 @@
+package uk.gov.nationalarchives.tdr.api.core.monitoring
+
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest}
+
+object Metrics {
+  private val metricNamespace = sys.env.getOrElse("CLOUDWATCH_METRIC_NAMESPACE", "TdrPrototypeDev")
+
+  def recordConsignmentCreation(transferringBody: String): Unit = {
+    val cloudWatchClient = CloudWatchAsyncClient.create()
+    val transferringBodyDimension = Dimension.builder()
+      .name("TransferringBody")
+      .value(transferringBody)
+      .build()
+    val metricDatum = MetricDatum.builder()
+      .metricName("ConsignmentCreated")
+      .value(1d)
+      .dimensions(transferringBodyDimension)
+      .build()
+    val metricRequest = PutMetricDataRequest.builder()
+      .namespace(metricNamespace)
+      .metricData(metricDatum)
+      .build()
+    cloudWatchClient.putMetricData(metricRequest)
+  }
+}

--- a/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/monitoring/Metrics.scala
+++ b/core/src/main/scala/uk/gov/nationalarchives/tdr/api/core/monitoring/Metrics.scala
@@ -2,18 +2,31 @@ package uk.gov.nationalarchives.tdr.api.core.monitoring
 
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
 import software.amazon.awssdk.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest}
+import uk.gov.nationalarchives.tdr.api.core.db.dao.ConsignmentDao
 
-object Metrics {
+import scala.concurrent.ExecutionContext
+
+class Metrics(consignmentDao: ConsignmentDao)(implicit val executionContext: ExecutionContext) {
   private val metricNamespace = sys.env.getOrElse("CLOUDWATCH_METRIC_NAMESPACE", "TdrPrototypeDev")
 
   def recordConsignmentCreation(transferringBody: String): Unit = {
+    recordConsignmentMetric("ConsignmentCreated", transferringBody)
+  }
+
+  def recordConsignmentTransferConfirmation(consignmentId: Int): Unit = {
+    consignmentDao.get(consignmentId).foreach(_.foreach(consignment => {
+      recordConsignmentMetric("ConsignmentTransferConfirmed", consignment.transferringBody)
+    }))
+  }
+
+  private def recordConsignmentMetric(metricName: String, transferringBody: String): Unit = {
     val cloudWatchClient = CloudWatchAsyncClient.create()
     val transferringBodyDimension = Dimension.builder()
       .name("TransferringBody")
       .value(transferringBody)
       .build()
     val metricDatum = MetricDatum.builder()
-      .metricName("ConsignmentCreated")
+      .metricName(metricName)
       .value(1d)
       .dimensions(transferringBodyDimension)
       .build()


### PR DESCRIPTION
Send metrics to CloudWatch when creating or confirming a transfer. This will help us see what custom metrics for real events look like in CloudWatch and Grafana.